### PR TITLE
minimal xkb fi symbols with asciicircum

### DIFF
--- a/custom-packages/digabios/xkb-symbols/fi
+++ b/custom-packages/digabios/xkb-symbols/fi
@@ -1,0 +1,65 @@
+//filtered xkb fi symbols with dead circumflex removed
+
+default  partial alphanumeric_keys
+
+hidden partial alphanumeric_keys
+xkb_symbols "fi" {
+
+    // Classic Finnish keyboard layout with dead keys
+
+    key <TLDE> { [  section,         onehalf,          onequarter,            threequarters         ] };
+    key <AE01> { [  1,               exclam,           exclamdown,            onesuperior           ] };
+    key <AE02> { [  2,               quotedbl,         at,                    twosuperior           ] };
+    key <AE03> { [  3,               numbersign,       sterling,              threesuperior         ] };
+    key <AE04> { [  4,               currency,         dollar,                cent                  ] };
+    key <AE05> { [  5,               percent,          EuroSign,              masculine             ] };
+    key <AE06> { [  6,               ampersand,        yen,                   ordfeminine           ] };
+    key <AE07> { [  7,               slash,            braceleft,             plusminus             ] };
+    key <AE08> { [  8,               parenleft,        bracketleft,           less                  ] };
+    key <AE09> { [  9,               parenright,       bracketright,          greater               ] };
+    key <AE10> { [  0,               equal,            braceright,            degree                ] };
+    key <AE11> { [  plus,            question,         backslash,             questiondown          ] };
+    key <AE12> { [  dead_acute,      dead_grave,       dead_cedilla,          dead_ogonek           ] };
+
+    key <AD01> { [  q,               Q,                q,                     Q                     ] };
+    key <AD02> { [  w,               W,                w,                     W                     ] };
+    key <AD03> { [  e,               E,                EuroSign,              cent                  ] };
+    key <AD04> { [  r,               R,                registered,            NoSymbol              ] };
+    key <AD05> { [  t,               T,                thorn,                 THORN                 ] };
+    key <AD06> { [  y,               Y,                y,                     Y                     ] };
+    key <AD07> { [  u,               U,                u,                     U                     ] };
+    key <AD08> { [  i,               I,                idotless,              bar                   ] };
+    key <AD09> { [  o,               O,                o,                     O                     ] };
+    key <AD10> { [  p,               P,                paragraph,             NoSymbol              ] };
+    key <AD11> { [  aring,           Aring,            oe,                    OE                    ] };
+    key <AD12> { [  dead_diaeresis,  asciicircum,       dead_tilde,            dead_caron            ] };
+
+    key <AC01> { [  a,               A,                schwa,                 SCHWA                 ] };
+    key <AC02> { [  s,               S,                scaron,                Scaron                ] };
+    key <AC03> { [  d,               D,                eth,                   ETH                   ] };
+    key <AC04> { [  f,               F,                f,                     F                     ] };
+    key <AC05> { [  g,               G,                eng,                   ENG                   ] };
+    key <AC06> { [  h,               H,                h,                     H                     ] };
+    key <AC07> { [  j,               J,                j,                     J                     ] };
+    key <AC08> { [  k,               K,                kra,                   NoSymbol              ] };
+    key <AC09> { [  l,               L,                dead_stroke,           NoSymbol              ] };
+    key <AC10> { [  odiaeresis,      Odiaeresis,       oslash,                Oslash                ] };
+    key <AC11> { [  adiaeresis,      Adiaeresis,       ae,                    AE                    ] };
+    key <BKSL> { [  apostrophe,      asterisk,         dead_caron,            dead_breve            ] };
+
+    key <LSGT> { [  less,            greater,          bar,                   brokenbar             ] };
+    key <AB01> { [  z,               Z,                zcaron,                Zcaron                ] };
+    key <AB02> { [  x,               X,                multiply,              division              ] };
+    key <AB03> { [  c,               C,                copyright,             cent                  ] };
+    key <AB04> { [  v,               V,                v,                     V                     ] };
+    key <AB05> { [  b,               B,                ssharp,                NoSymbol              ] };
+    key <AB06> { [  n,               N,                ntilde,                Ntilde                ] };
+    key <AB07> { [  m,               M,                mu,                    NoSymbol              ] };
+    key <AB08> { [  comma,           semicolon,        dead_cedilla,          dead_ogonek           ] };
+    key <AB09> { [  period,          colon,            periodcentered,        notsign               ] };
+    key <AB10> { [  minus,           underscore,       hyphen,                dead_macron           ] };
+
+    include "nbsp(level4)"
+    include "kpdl(comma)"
+    include "level3(ralt_switch)"
+};


### PR DESCRIPTION
Reason:
Makes inserting powers in Ti-Nspire easier.

Problem to fix: Before one couldn't use keyboard to insert powers by typing in Nspire because by default deadcircumflex caused unwanted superscript characters instead. (superscript can't be used for math)

Wanted behavior: make circumflex insert circumflex. Nspire will register circumflex+number that it can use for math.

PS I have no idea if this will compile correctly but you get the idea about not using dead circumflex