### PR TITLE
Disable DRRS for "HP EliteBook 820 G1" and "HP EliteBook 840 G1".

### DIFF
--- a/target/default/hooks/9100-disable-drrs-conditionally.hook.chroot
+++ b/target/default/hooks/9100-disable-drrs-conditionally.hook.chroot
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+systemctl enable disable-drrs-conditionally.service

--- a/target/default/includes.chroot/etc/systemd/system/disable-drrs-conditionally.service
+++ b/target/default/includes.chroot/etc/systemd/system/disable-drrs-conditionally.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Disable DRRS conditionally
+After=multi-user.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/lib/disable-drrs-conditionally
+
+[Install]
+WantedBy=multi-user.target

--- a/target/default/includes.chroot/lib/systemd/system-sleep/disable-drrs-conditionally
+++ b/target/default/includes.chroot/lib/systemd/system-sleep/disable-drrs-conditionally
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+test "$1" = 'post' || exit 0
+
+/usr/local/lib/disable-drrs-conditionally
+exit 0

--- a/target/default/includes.chroot/usr/local/lib/disable-drrs-conditionally
+++ b/target/default/includes.chroot/usr/local/lib/disable-drrs-conditionally
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+set -eu
+
+product_name="$(dmidecode -s system-product-name)"
+
+case "$product_name" in
+  "HP EliteBook 820 G1"|"HP EliteBook 840 G1") ;;
+  *) exit 0 ;;
+esac
+
+test -e /sys/kernel/debug/dri/0/i915_drrs_ctl    || exit 0
+test -e /sys/kernel/debug/dri/0/i915_drrs_status || exit 0
+
+for i in $(seq 20); do
+  if grep -q CRTC /sys/kernel/debug/dri/0/i915_drrs_status; then
+    echo 0 > /sys/kernel/debug/dri/0/i915_drrs_ctl
+    exit 0
+  fi
+  sleep 1
+done
+
+exit 1


### PR DESCRIPTION
The problem with i915 driver DRRS (Dynamic Refresh Rate Switching)
for these hosts that apparently many (not all!) of these computers
have a manufacturing defect on their displays.  They advertise
that they support DRRS for better power management, but actually
fail sometimes with either screen blanking or distortion when
screen refresh rate is raised from 40Hz to 60Hz.

The problem does not exist for old (3.16 and such) Linux kernels
where DRRS is not supported.  Some newer kernels (maybe 4.17
onwards?) support runtime disabling of DRRS through
"/sys/kernel/debug/dri/0/i915_drrs_ctl".

This change disables (through this runtime mechanism)
DRRS when product name matches "HP EliteBook 820 G1" or
"HP EliteBook 840 G1".

See https://lists.openwall.net/linux-kernel/2018/03/12/339
for more information.  The proposed patch to disable DRRS
right from kernel command line was not accepted.

Note this commit is not actually tested because it appears
building DigabiOS is not possible except in a special environment
(?).  The actual mechanisms should be effective, though.