### PR TITLE
Disable beeping

### DIFF
--- a/custom-packages/digabios/modprobe.d/disable-beep.conf
+++ b/custom-packages/digabios/modprobe.d/disable-beep.conf
@@ -1,0 +1,2 @@
+blacklist pcspkr
+blacklist snd_pcsp


### PR DESCRIPTION
Disable beeping by blacklisting the PC speaker drivers. ABITTI2118E uses pcspkr, but this may change: my computer started using snd_pcsp in February with a new kernel version.