### PR TITLE
Hard-code font path the grub $prefix env may point to another location

### DIFF
--- a/target/default/bootloaders/grub-pc/grub.cfg
+++ b/target/default/bootloaders/grub-pc/grub.cfg
@@ -1,9 +1,9 @@
 set default=0
 set timeout=10
 
-loadfont $prefix/dejavu-bold-16.pf2
-loadfont $prefix/dejavu-bold-14.pf2
-loadfont $prefix/unicode.pf2
+loadfont /live/grub/dejavu-bold-16.pf2
+loadfont /live/grub/dejavu-bold-14.pf2
+loadfont /live/grub/unicode.pf2
 set gfxmode=auto
 set gfxpayload=keep
 insmod all_video


### PR DESCRIPTION
Needed on Windows where `$prefix` may point to other than `/live/grub`. Should not break booting from USB media.