### PR TITLE
Fix anarâškielâ (Inari Sami) keyboard

### DIFF
--- a/custom-packages/digabios/xkb-symbols/smn
+++ b/custom-packages/digabios/xkb-symbols/smn
@@ -41,7 +41,7 @@ xkb_symbols "basic" {
     key <AC10> { [    dstroke,    Dstroke, odiaeresis, Odiaeresis ] };
     key <AC11> { [ adiaeresis, Adiaeresis,         ae,         AE ] };
     key <AD13> { [ apostrophe,   asterisk ] };
-    key <AB00> { [     zcaron,     Zcaron,      U01EF,      U01EE ] };
+    key <LSGT> { [     zcaron,     Zcaron,       less,    greater ] };
     key <AB01> { [          z,          Z,        ezh,        EZH ] };
     key <AB02> { [     ccaron,     Ccaron,          x,          X ] };
     key <AB03> { [          c,          C,   ccedilla,   Ccedilla ] };


### PR DESCRIPTION
The DigabiOS Inari Sami keyboard follows the
[Divvun layout](https://divvun.no/fi/keyboards/layout-smn.html). In the Linux implementation the ž/Ž was copied from Northern Sami keyboard layout.

This fix implements the ž/Ž key as described in the layout.